### PR TITLE
Fix potential buffer overrun in print_ne_instr

### DIFF
--- a/src/ne_segment.c
+++ b/src/ne_segment.c
@@ -131,7 +131,7 @@ static int print_ne_instr(const struct segment *seg, word ip, byte *p, const str
     int bits = (seg->flags & 0x2000) ? 32 : 16;
 
     const char *comment = NULL;
-    char ip_string[10];
+    char ip_string[11];
 
     len = get_instr(ip, p, &instr, bits);
 


### PR DESCRIPTION
seg->cs can be up to 5 decimal characters (65535) which causes
the terminating 0 character to be written out of bounds by the sprintf
on line 138.