### PR TITLE
Make declaration match definition on platforms where `off_t` is not `long`

### DIFF
--- a/src/ne.h
+++ b/src/ne.h
@@ -103,7 +103,7 @@ struct ne {
     struct segment *segments;
 };
 
-extern void readne(long offset_ne, struct ne *ne);
+extern void readne(off_t offset_ne, struct ne *ne);
 extern void freene(struct ne *ne);
 
 /* in ne_resource.c */


### PR DESCRIPTION
Thanks for writing this—it's great!

I had to make a trivial header fix to get it to build on macOS.

    commit 80a477a64932d357ca7473c77f242769c26866fd
    
    ne: Make declaration match definition on platforms where `off_t` is not `long`.
    
    On Darwin/x86_64, `off_t` is `long long`.  (Both are 64-bits wide.)
