### PR TITLE
Handle short MZ files

### DIFF
--- a/src/dump.c
+++ b/src/dump.c
@@ -74,9 +74,9 @@ static void dump_file(char *file){
     offset = read_dword(0x3c);
     magic = read_word(offset);
 
-    if (magic == 0x4550)
+    if (magic == 0x4550) /* PE */
         dumppe(offset);
-    else if (magic == 0x454e)
+    else if (magic == 0x454e) /* NE */
         dumpne(offset);
     else
         dumpmz();

--- a/src/dump.c
+++ b/src/dump.c
@@ -72,6 +72,12 @@ static void dump_file(char *file){
     }
 
     offset = read_dword(0x3c);
+    if (offset >= st.st_size)
+    {
+        dumpmz();
+        return;
+    }
+
     magic = read_word(offset);
 
     if (magic == 0x4550) /* PE */

--- a/src/dump.c
+++ b/src/dump.c
@@ -65,18 +65,21 @@ static void dump_file(char *file){
     magic = read_word(0);
 
     printf("File: %s\n", file);
-    if (magic == 0x5a4d){ /* MZ */
-        offset = read_dword(0x3c);
-        magic = read_word(offset);
-
-        if (magic == 0x4550)
-            dumppe(offset);
-        else if (magic == 0x454e)
-            dumpne(offset);
-        else
-            dumpmz();
-    } else
+    if (magic != 0x5a4d) /* MZ */
+    {
         fprintf(stderr, "File format not recognized\n");
+        return;
+    }
+
+    offset = read_dword(0x3c);
+    magic = read_word(offset);
+
+    if (magic == 0x4550)
+        dumppe(offset);
+    else if (magic == 0x454e)
+        dumpne(offset);
+    else
+        dumpmz();
 
     return;
 }


### PR DESCRIPTION
As per:

  https://reverseengineering.stackexchange.com/questions/12993/how-to-quickly-distinguish-pe-dll-dos-mz-files-based-on-magic-numbers#answer-14031

check whether the value for `e_lfanew` is within the file, as old
MZ files may use that location for something else, creating an
invalid offset